### PR TITLE
Added KeyCreateEvent for API usage - fires when creating a key.

### DIFF
--- a/src/com/github/derwisch/loreLocks/KeyCreateEvent.java
+++ b/src/com/github/derwisch/loreLocks/KeyCreateEvent.java
@@ -1,0 +1,41 @@
+package com.github.derwisch.loreLocks;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.HandlerList;
+import org.bukkit.event.player.PlayerEvent;
+import org.bukkit.inventory.ItemStack;
+
+public class KeyCreateEvent extends PlayerEvent {
+    private ItemStack key;
+
+    public KeyCreateEvent(Player player, ItemStack key) {
+        super(player);
+
+        this.setKey(key);
+    }
+
+    /**
+     * @return The key being created
+     */
+    public ItemStack getKey() {
+        return key;
+    }
+
+    /**
+     * @return Set the key being created
+     */
+    public void setKey(ItemStack key) {
+        this.key = key;
+    }
+
+    private static final HandlerList handlers = new HandlerList();
+
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+}

--- a/src/com/github/derwisch/loreLocks/LoreLocksListener.java
+++ b/src/com/github/derwisch/loreLocks/LoreLocksListener.java
@@ -93,8 +93,8 @@ public class LoreLocksListener implements Listener {
 	    		if (LoreLocks.instance.IsLock(currentItem)) {
 	    			ItemStack key = LoreLocks.instance.CreateKey(currentItem);
 	    			KeyCreateEvent keyCreateEvent = new KeyCreateEvent((Player) event.getWhoClicked(), key);
-                    LoreLocks.instance.getServer().getPluginManager().callEvent(keyCreateEvent);
-	    	    	event.setCursor(keyCreateEvent.getKey());
+	    			LoreLocks.instance.getServer().getPluginManager().callEvent(keyCreateEvent);
+	    			event.setCursor(keyCreateEvent.getKey());
 	    	    	event.setCancelled(true);
 	        	}
 	    	}

--- a/src/com/github/derwisch/loreLocks/LoreLocksListener.java
+++ b/src/com/github/derwisch/loreLocks/LoreLocksListener.java
@@ -92,7 +92,9 @@ public class LoreLocksListener implements Listener {
 	    	if (LoreLocks.instance.IsLockPick(cursorItem)) {
 	    		if (LoreLocks.instance.IsLock(currentItem)) {
 	    			ItemStack key = LoreLocks.instance.CreateKey(currentItem);
-	    	    	event.setCursor(key);
+	    			KeyCreateEvent keyCreateEvent = new KeyCreateEvent((Player) event.getWhoClicked(), key);
+                    LoreLocks.instance.getServer().getPluginManager().callEvent(keyCreateEvent);
+	    	    	event.setCursor(keyCreateEvent.getKey());
 	    	    	event.setCancelled(true);
 	        	}
 	    	}


### PR DESCRIPTION
Please accept this pull request, I would love to let my plugin "Soulbound" hook into LoreLocks. This would allow automatic soulbinding of keys.

https://github.com/TfT-02/Soulbound/commit/6b8fc62d74b4fde316e4217a8a38f6898b6b2fb3
